### PR TITLE
変数のタイポを修正

### DIFF
--- a/notebooks/31_transformer.ipynb
+++ b/notebooks/31_transformer.ipynb
@@ -267,7 +267,7 @@
     "    def __call__(self, x):\n",
     "        h = self._onehot(x)\n",
     "        h = self.embed(h)\n",
-    "        h[idx == 10, :] = 0 \n",
+    "        h[x == 10, :] = 0\n",
     "        return h\n",
     "\n",
     "    def _onehot(self, idx):\n",


### PR DESCRIPTION
Embedding クラスの call 関数がタイポで動かなかったので修正．